### PR TITLE
Feat/detailed view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
       <header>
         <Navbar />
       </header>
-      <main>
+      <main className="bg-slate-700 pb-10 min-h-screen">
         <Routes>
           <Route
             path="/"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import Navbar from "./ui/Navbar";
 import PokemonList from "./components/PokemonList";
+import { Routes, Route } from "react-router";
+import Details from "./pages/Details";
 
 function App() {
   return (
@@ -8,7 +10,10 @@ function App() {
         <Navbar />
       </header>
       <main>
-        <PokemonList />
+        <Routes>
+          <Route path="/" element={<PokemonList />} />
+          <Route path="/details" element={<Details />} />
+        </Routes>
       </main>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,17 @@ import Navbar from "./ui/Navbar";
 import PokemonList from "./components/PokemonList";
 import { Routes, Route } from "react-router";
 import Details from "./pages/Details";
+import { useState } from "react";
+import { usePokemon, usePokemonDetails } from "./services/queries";
 
 function App() {
+  // Get the pokemons results which is an array of pokemon
+  const pokemon = usePokemon();
+  // Uses pokemon and maps over results to create a query endpoint for each pokemon
+  const pokemonDetails = usePokemonDetails(pokemon);
+  // State to show which pokemon card was clicked
+  const [, setSelectedPokemon] = useState("");
+
   return (
     <>
       <header>
@@ -11,8 +20,19 @@ function App() {
       </header>
       <main>
         <Routes>
-          <Route path="/" element={<PokemonList />} />
-          <Route path="/:pokemon" element={<Details />} />
+          <Route
+            path="/"
+            element={
+              <PokemonList
+                pokemonDetails={pokemonDetails}
+                setSelectedPokemon={setSelectedPokemon}
+              />
+            }
+          />
+          <Route
+            path="/:pokemon"
+            element={<Details pokemonDetails={pokemonDetails} />}
+          />
         </Routes>
       </main>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
       <main>
         <Routes>
           <Route path="/" element={<PokemonList />} />
-          <Route path="/details" element={<Details />} />
+          <Route path="/:pokemon" element={<Details />} />
         </Routes>
       </main>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,8 @@ import { useState } from "react";
 import { usePokemon, usePokemonDetails } from "./services/queries";
 
 function App() {
-  // Get the pokemons results which is an array of pokemon
   const pokemon = usePokemon();
-  // Uses pokemon and maps over results to create a query endpoint for each pokemon
   const pokemonDetails = usePokemonDetails(pokemon);
-  // State to show which pokemon card was clicked
   const [, setSelectedPokemon] = useState("");
 
   return (

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -11,11 +11,17 @@ interface PokemonProps {
 const Pokemon = ({ name, images, types, setSelectedPokemon }: PokemonProps) => {
   return (
     <div
-      className="border cursor-pointer rounded-xl capitalize"
+      className="border cursor-pointer rounded-xl capitalize bg-slate-100 py-6"
       onClick={() => setSelectedPokemon(name)}
     >
       <Link to={name}>
-        <img className="mx-auto" src={images[0]} alt={name} />
+        <div className="w-[120px] h-auto mx-auto">
+          <img
+            className="mx-auto bg-gray-300 rounded-full p-2"
+            src={images[0]}
+            alt={name}
+          />
+        </div>
         <p>{name}</p>
         <div className="flex justify-center gap-x-2">
           {types.map((type) => (

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { formattedPokemonId } from "../utils/utils";
+import { TypeColorTypes } from "../types/pokemon";
 
 interface PokemonProps {
   id: number;
@@ -9,7 +10,7 @@ interface PokemonProps {
   setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const typeColors = {
+const typeColors: TypeColorTypes = {
   grass: "#78C850",
   fire: "#F08030",
   water: "#6890F0",
@@ -58,7 +59,7 @@ const Pokemon = ({
           {types.map((type) => (
             <p
               style={{
-                backgroundColor: typeColors[type],
+                backgroundColor: typeColors[type as keyof TypeColorTypes],
                 padding: "2px 0",
                 borderRadius: "4px",
                 display: "inline-block",

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -9,6 +9,27 @@ interface PokemonProps {
   setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
 
+const typeColors = {
+  grass: "#78C850",
+  fire: "#F08030",
+  water: "#6890F0",
+  bug: "#A8B820",
+  normal: "#A8A878",
+  poison: "#A040A0",
+  electric: "#F8D030",
+  ground: "#E0C068",
+  fairy: "#EE99AC",
+  fighting: "#C03028",
+  psychic: "#F85888",
+  rock: "#B8A038",
+  ghost: "#705898",
+  ice: "#98D8D8",
+  dragon: "#7038F8",
+  dark: "#705848",
+  steel: "#B8B8D0",
+  flying: "#A890F0",
+};
+
 const Pokemon = ({
   id,
   name,
@@ -18,9 +39,12 @@ const Pokemon = ({
 }: PokemonProps) => {
   return (
     <div
-      className="border-4 cursor-pointer rounded-xl capitalize bg-slate-100 py-6 hover:border-red-500 "
+      className="border-4 cursor-pointer rounded-xl capitalize bg-slate-100 py-6 hover:border-red-600 relative"
       onClick={() => setSelectedPokemon(name)}
     >
+      <p className="absolute right-2 top-2 text-sm text-blue-900">
+        #{formattedPokemonId(String(id))}
+      </p>
       <Link to={name}>
         <div className="w-[120px] h-auto mx-auto">
           <img
@@ -29,11 +53,22 @@ const Pokemon = ({
             alt={name}
           />
         </div>
-        <p>#{formattedPokemonId(String(id))}</p>
-        <p>{name}</p>
-        <div className="flex justify-center gap-x-2">
+        <h3 className="text-lg font-medium">{name}</h3>
+        <div className="flex justify-center gap-x-2 mt-2 text-white">
           {types.map((type) => (
-            <p key={type}>{type}</p>
+            <p
+              style={{
+                backgroundColor: typeColors[type],
+                padding: "2px 0",
+                borderRadius: "4px",
+                display: "inline-block",
+                fontSize: "14px",
+                width: "70px",
+              }}
+              key={type}
+            >
+              {type}
+            </p>
           ))}
         </div>
       </Link>

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { formattedPokemonId } from "../utils/utils";
 
 interface PokemonProps {
   id: number;
@@ -8,7 +9,13 @@ interface PokemonProps {
   setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const Pokemon = ({ name, images, types, setSelectedPokemon }: PokemonProps) => {
+const Pokemon = ({
+  id,
+  name,
+  images,
+  types,
+  setSelectedPokemon,
+}: PokemonProps) => {
   return (
     <div
       className="border cursor-pointer rounded-xl capitalize bg-slate-100 py-6"
@@ -22,6 +29,7 @@ const Pokemon = ({ name, images, types, setSelectedPokemon }: PokemonProps) => {
             alt={name}
           />
         </div>
+        <p>#{formattedPokemonId(String(id))}</p>
         <p>{name}</p>
         <div className="flex justify-center gap-x-2">
           {types.map((type) => (

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -8,13 +8,7 @@ interface PokemonProps {
   setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const Pokemon = ({
-  id,
-  name,
-  image,
-  types,
-  setSelectedPokemon,
-}: PokemonProps) => {
+const Pokemon = ({ name, image, types, setSelectedPokemon }: PokemonProps) => {
   return (
     <div
       className="border cursor-pointer rounded-xl capitalize"

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { formattedPokemonId } from "../utils/utils";
+import { formattedPokemonId, typeColors } from "../utils/utils";
 import { TypeColorTypes } from "../types/pokemon";
 
 interface PokemonProps {
@@ -9,27 +9,6 @@ interface PokemonProps {
   types: string[];
   setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
-
-const typeColors: TypeColorTypes = {
-  grass: "#78C850",
-  fire: "#F08030",
-  water: "#6890F0",
-  bug: "#A8B820",
-  normal: "#A8A878",
-  poison: "#A040A0",
-  electric: "#F8D030",
-  ground: "#E0C068",
-  fairy: "#EE99AC",
-  fighting: "#C03028",
-  psychic: "#F85888",
-  rock: "#B8A038",
-  ghost: "#705898",
-  ice: "#98D8D8",
-  dragon: "#7038F8",
-  dark: "#705848",
-  steel: "#B8B8D0",
-  flying: "#A890F0",
-};
 
 const Pokemon = ({
   id,

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -3,19 +3,19 @@ import { Link } from "react-router-dom";
 interface PokemonProps {
   id: number;
   name: string;
-  image: string;
+  images: string[];
   types: string[];
   setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const Pokemon = ({ name, image, types, setSelectedPokemon }: PokemonProps) => {
+const Pokemon = ({ name, images, types, setSelectedPokemon }: PokemonProps) => {
   return (
     <div
       className="border cursor-pointer rounded-xl capitalize"
       onClick={() => setSelectedPokemon(name)}
     >
       <Link to={name}>
-        <img className="mx-auto" src={image} alt={name} />
+        <img className="mx-auto" src={images[0]} alt={name} />
         <p>{name}</p>
         <div className="flex justify-center gap-x-2">
           {types.map((type) => (

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -18,7 +18,7 @@ const Pokemon = ({
 }: PokemonProps) => {
   return (
     <div
-      className="border cursor-pointer rounded-xl capitalize bg-slate-100 py-6"
+      className="border-4 cursor-pointer rounded-xl capitalize bg-slate-100 py-6 hover:border-red-500 "
       onClick={() => setSelectedPokemon(name)}
     >
       <Link to={name}>

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -5,11 +5,21 @@ interface PokemonProps {
   name: string;
   image: string;
   types: string[];
+  setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const Pokemon = ({ id, name, image, types }: PokemonProps) => {
+const Pokemon = ({
+  id,
+  name,
+  image,
+  types,
+  setSelectedPokemon,
+}: PokemonProps) => {
   return (
-    <div className="border cursor-pointer rounded-xl capitalize">
+    <div
+      className="border cursor-pointer rounded-xl capitalize"
+      onClick={() => setSelectedPokemon(name)}
+    >
       <Link to={name}>
         <img className="mx-auto" src={image} alt={name} />
         <p>{name}</p>

--- a/src/components/Pokemon.tsx
+++ b/src/components/Pokemon.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 interface PokemonProps {
   id: number;
   name: string;
@@ -8,13 +10,15 @@ interface PokemonProps {
 const Pokemon = ({ id, name, image, types }: PokemonProps) => {
   return (
     <div className="border cursor-pointer rounded-xl capitalize">
-      <img className="mx-auto" src={image} alt={name} />
-      <p>{name}</p>
-      <div className="flex justify-center gap-x-2">
-        {types.map((type) => (
-          <p key={type}>{type}</p>
-        ))}
-      </div>
+      <Link to={name}>
+        <img className="mx-auto" src={image} alt={name} />
+        <p>{name}</p>
+        <div className="flex justify-center gap-x-2">
+          {types.map((type) => (
+            <p key={type}>{type}</p>
+          ))}
+        </div>
+      </Link>
     </div>
   );
 };

--- a/src/components/PokemonList.tsx
+++ b/src/components/PokemonList.tsx
@@ -44,7 +44,7 @@ const PokemonList = ({
   );
 
   return (
-    <div className="grid grid-cols-4 gap-5 pt-10 text-center px-4">
+    <div className="grid grid-cols-3 gap-8 pt-10 text-center max-w-[1200px] mx-auto">
       {pokemonElements}
     </div>
   );

--- a/src/components/PokemonList.tsx
+++ b/src/components/PokemonList.tsx
@@ -6,7 +6,7 @@ interface PokemonListProps {
     {
       name: string;
       id: number;
-      sprites: string;
+      sprites: string[];
       types: string[];
     },
     Error
@@ -36,7 +36,7 @@ const PokemonList = ({
           key={pokemon.data.id}
           id={pokemon.data.id}
           name={pokemon.data.name}
-          image={pokemon.data.sprites}
+          images={pokemon.data.sprites}
           types={pokemon.data.types}
           setSelectedPokemon={setSelectedPokemon}
         />

--- a/src/components/PokemonList.tsx
+++ b/src/components/PokemonList.tsx
@@ -1,10 +1,23 @@
-import { usePokemon, usePokemonDetails } from "../services/queries";
+import { UseQueryResult } from "@tanstack/react-query";
 import Pokemon from "./Pokemon";
 
-const PokemonList = () => {
-  const pokemon = usePokemon();
-  const pokemonDetails = usePokemonDetails(pokemon);
+interface PokemonListProps {
+  pokemonDetails: UseQueryResult<
+    {
+      name: string;
+      id: number;
+      sprites: string;
+      types: string[];
+    },
+    Error
+  >[];
+  setSelectedPokemon: React.Dispatch<React.SetStateAction<string>>;
+}
 
+const PokemonList = ({
+  pokemonDetails,
+  setSelectedPokemon,
+}: PokemonListProps) => {
   const areAnyPending = pokemonDetails.some(
     (query) => query.status === "pending"
   );
@@ -25,6 +38,7 @@ const PokemonList = () => {
           name={pokemon.data.name}
           image={pokemon.data.sprites}
           types={pokemon.data.types}
+          setSelectedPokemon={setSelectedPokemon}
         />
       )
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,16 @@ import App from "./App.tsx";
 import "./index.css";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { BrowserRouter } from "react-router-dom";
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </StrictMode>

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,5 +1,13 @@
+import { useNavigate } from "react-router-dom";
+
 const Details = () => {
-  return <span>Details Page</span>;
+  const navigate = useNavigate();
+
+  return (
+    <div>
+      <button onClick={() => navigate(-1)}>Go Back</button>
+    </div>
+  );
 };
 
 export default Details;

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,7 +1,6 @@
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { usePokemonAbility, usePokemonSpecies } from "../services/queries";
-import { getPokemonEvolutions } from "../services/api";
 import { formattedPokemonId } from "../utils/utils";
 
 interface PokemonProps {
@@ -38,14 +37,6 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   );
   const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
   const pokemonAbility = usePokemonAbility(pokemonData?.data?.ability.url);
-
-  console.log(pokemonData?.data);
-
-  // const pokemonEvolutions = useQuery({
-  //   queryKey: ["evolutions"],
-  //   queryFn: () =>
-  //     getPokemonEvolutions(pokemonSpecies?.data.evolution_chain.url),
-  // });
 
   if (!pokemonData)
     return (
@@ -95,15 +86,6 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
               </li>
             ))}
           </ul>
-          <h2>Evolutions</h2>
-          {/* <p> */}
-          {/* {pokemonData.data.name} ---= */}
-          {/* {pokemonEvolutions?.data?.chain?.evolves_to[0].species.name} ---= */}
-          {/* {
-              pokemonEvolutions?.data?.chain?.evolves_to[0].evolves_to[0]
-                .species.name
-            } */}
-          {/* </p> */}
         </div>
       </section>
     );

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,7 +1,8 @@
 import { UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { usePokemonAbility, usePokemonSpecies } from "../services/queries";
-import { formattedPokemonId } from "../utils/utils";
+import { formattedPokemonId, typeColors } from "../utils/utils";
+import { TypeColorTypes } from "../types/pokemon";
 
 interface PokemonProps {
   pokemonDetails: UseQueryResult<
@@ -49,43 +50,56 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         <button className="my-6 text-white" onClick={() => navigate(-1)}>
           &larr; Go Back
         </button>
-        <div className="bg-slate-100 py-4 rounded-xl">
-          <h2 className="text-center capitalize text-2xl font-semibold ">
+        <div className="bg-slate-100 py-8 rounded-xl">
+          <h2 className="text-center capitalize text-2xl font-semibold pb-4">
             {pokemonData.data.name}{" "}
             <span className=" font-light">
               | #{formattedPokemonId(String(pokemonData.data.id))}
             </span>
           </h2>
-          <div className="flex border pt-4">
-            <div className="w-[50%] border">
+          <div className="flex w-[90%] justify-center gap-x-6 mx-auto py-4">
+            <div className="w-[35%]">
               <img
-                className="w-full object-cover "
+                className="object-cover bg-gray-300 rounded-lg"
                 src={pokemonData.data.sprites[1]}
                 alt={pokemonData.data.name}
               />
             </div>
-            <div className="border W-[50%]">
+            <div className="w-[55%] space-y-2">
               <p>{pokemonSpecies.data?.flavor_text_entries[0].flavor_text}</p>
-              <h3 className="text-xl font-medium">Types</h3>
-              <ul className="flex gap-x-2 capitalize">
+              <h3 className="text-xl font-medium">Type</h3>
+              <ul className="flex gap-x-2 capitalize text-center text-white">
                 {pokemonData.data.types.map((type) => (
-                  <li key={type}>{type}</li>
+                  <li
+                    style={{
+                      backgroundColor: typeColors[type as keyof TypeColorTypes],
+                      padding: "2px 0",
+                      borderRadius: "4px",
+                      display: "inline-block",
+                      width: "70px",
+                    }}
+                    key={type}
+                  >
+                    {type}
+                  </li>
                 ))}
               </ul>
               <p>Height: {pokemonData.data.height}</p>
               <p>Weight: {pokemonData.data.weight}</p>
               <p>Growth Rate: {pokemonSpecies.data?.growth_rate.name}</p>
-              <p>Ability: {pokemonData.data.ability.name}</p>
+              <p className="capitalize">
+                Ability: {pokemonData.data.ability.name}
+              </p>
               <p>{pokemonAbility.data?.effect_entries[0].effect}</p>
             </div>
           </div>
-          <ul>
+          {/* <ul>
             {pokemonData.data.stats.map((stat) => (
               <li key={stat.stat.url}>
                 {stat.stat.name}: {stat.base_stat}
               </li>
             ))}
-          </ul>
+          </ul> */}
         </div>
       </section>
     );

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -66,14 +66,14 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   if (pokemonData.data) {
     return (
       <section className="max-w-[1200px] mx-auto">
-        <button className="m-4" onClick={() => navigate(-1)}>
+        <button className="my-6 text-white" onClick={() => navigate(-1)}>
           &larr; Go Back
         </button>
-        <div>
-          <h2 className="text-center capitalize text-2xl font-semibold">
+        <div className="bg-slate-100 py-4 rounded-xl">
+          <h2 className="text-center capitalize text-2xl font-semibold ">
             {pokemonData.data.name}{" "}
             <span className=" font-light">
-              #{formatPokemonId(String(pokemonData.data.id))}
+              | #{formatPokemonId(String(pokemonData.data.id))}
             </span>
           </h2>
           <div className="flex border pt-4">

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -8,7 +8,7 @@ interface PokemonProps {
     {
       name: string;
       id: number;
-      sprites: string;
+      sprites: string[];
       types: string[];
       height: number;
       weight: number;
@@ -38,16 +38,25 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
   const pokemonAbility = usePokemonAbility(pokemonData?.data?.ability.url);
 
-  const pokemonEvolutions = useQuery({
-    queryKey: ["evolutions"],
-    queryFn: () =>
-      getPokemonEvolutions(pokemonSpecies?.data.evolution_chain.url),
-  });
+  console.log(pokemonData?.data);
 
-  // console.log(pokemonEvolutions?.data?.chain?.evolves_to[0]);
-  console.log(
-    pokemonEvolutions?.data?.chain.evolves_to[0].evolves_to[0].species.name
-  );
+  // const pokemonEvolutions = useQuery({
+  //   queryKey: ["evolutions"],
+  //   queryFn: () =>
+  //     getPokemonEvolutions(pokemonSpecies?.data.evolution_chain.url),
+  // });
+
+  const formatPokemonId = (pokemonId: string) => {
+    let formattedId;
+    if (pokemonId.length === 1) {
+      formattedId = `000${pokemonId}`;
+    } else if (pokemonId.length === 2) {
+      formattedId = `00${pokemonId}`;
+    } else if (pokemonId.length === 3) {
+      formattedId = `00${pokemonId}`;
+    }
+    return formattedId;
+  };
 
   if (!pokemonData)
     return (
@@ -56,41 +65,58 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
 
   if (pokemonData.data) {
     return (
-      <div>
-        <button onClick={() => navigate(-1)}>Go Back</button>
-        <h2>{pokemonData.data.name}</h2>
-        <img src={pokemonData.data.sprites} alt={pokemonData.data.name} />
-        <ul>
-          {pokemonData.data.types.map((type) => (
-            <li key={type}>{type}</li>
-          ))}
-        </ul>
-        <p>Height: {pokemonData.data.height}</p>
-        <p>Weight: {pokemonData.data.weight}</p>
-        <p>Growth Rate: {pokemonSpecies.data?.growth_rate.name}</p>
-        <p>
-          Pokedex Entry:
-          {pokemonSpecies.data?.flavor_text_entries[0].flavor_text}
-        </p>
-        <ul>
-          {pokemonData.data.stats.map((stat) => (
-            <li key={stat.stat.url}>
-              {stat.stat.name}: {stat.base_stat}
-            </li>
-          ))}
-        </ul>
-        <p>Ability: {pokemonData.data.ability.name}</p>
-        <p>{pokemonAbility.data?.effect_entries[0].effect}</p>
-        <h2>Evolutions</h2>
-        <p>
-          {pokemonData.data.name} ---=
-          {pokemonEvolutions?.data?.chain?.evolves_to[0].species.name} ---=
-          {
-            pokemonEvolutions?.data?.chain.evolves_to[0].evolves_to[0].species
-              .name
-          }
-        </p>
-      </div>
+      <section className="max-w-[1200px] mx-auto">
+        <button className="m-4" onClick={() => navigate(-1)}>
+          &larr; Go Back
+        </button>
+        <div>
+          <h2 className="text-center capitalize text-2xl font-semibold">
+            {pokemonData.data.name}{" "}
+            <span className=" font-light">
+              #{formatPokemonId(String(pokemonData.data.id))}
+            </span>
+          </h2>
+          <div className="flex border pt-4">
+            <div className="w-[50%] border">
+              <img
+                className="w-full object-cover "
+                src={pokemonData.data.sprites[1]}
+                alt={pokemonData.data.name}
+              />
+            </div>
+            <div className="border W-[50%]">
+              <p>{pokemonSpecies.data?.flavor_text_entries[0].flavor_text}</p>
+              <h3 className="text-xl font-medium">Types</h3>
+              <ul className="flex gap-x-2 capitalize">
+                {pokemonData.data.types.map((type) => (
+                  <li key={type}>{type}</li>
+                ))}
+              </ul>
+              <p>Height: {pokemonData.data.height}</p>
+              <p>Weight: {pokemonData.data.weight}</p>
+              <p>Growth Rate: {pokemonSpecies.data?.growth_rate.name}</p>
+              <p>Ability: {pokemonData.data.ability.name}</p>
+              <p>{pokemonAbility.data?.effect_entries[0].effect}</p>
+            </div>
+          </div>
+          <ul>
+            {pokemonData.data.stats.map((stat) => (
+              <li key={stat.stat.url}>
+                {stat.stat.name}: {stat.base_stat}
+              </li>
+            ))}
+          </ul>
+          <h2>Evolutions</h2>
+          {/* <p> */}
+          {/* {pokemonData.data.name} ---= */}
+          {/* {pokemonEvolutions?.data?.chain?.evolves_to[0].species.name} ---= */}
+          {/* {
+              pokemonEvolutions?.data?.chain?.evolves_to[0].evolves_to[0]
+                .species.name
+            } */}
+          {/* </p> */}
+        </div>
+      </section>
     );
   }
 };

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -8,6 +8,8 @@ interface PokemonProps {
       id: number;
       sprites: string;
       types: string[];
+      height: number;
+      weight: number;
     },
     Error
   >[];
@@ -16,11 +18,12 @@ interface PokemonProps {
 const Details = ({ pokemonDetails }: PokemonProps) => {
   const navigate = useNavigate();
   const pokemonEndpoint = useParams();
-  console.log(pokemonEndpoint.pokemon);
 
   const pokemonData = pokemonDetails.find(
     (pokemon) => pokemon.data?.name === pokemonEndpoint.pokemon
   );
+
+  console.log(pokemonData?.data);
 
   if (!pokemonData)
     return (
@@ -33,6 +36,13 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         <button onClick={() => navigate(-1)}>Go Back</button>
         <h2>{pokemonData.data.name}</h2>
         <img src={pokemonData.data.sprites} alt={pokemonData.data.name} />
+        <ul>
+          {pokemonData.data.types.map((type) => (
+            <li key={type}>{type}</li>
+          ))}
+        </ul>
+        <p>Height: {pokemonData.data.height}</p>
+        <p>Weight: {pokemonData.data.weight}</p>
       </div>
     );
   }

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,5 +1,6 @@
-import { UseQueryResult } from "@tanstack/react-query";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
+import { getPokemonSpecies } from "../services/api";
 
 interface PokemonProps {
   pokemonDetails: UseQueryResult<
@@ -18,12 +19,16 @@ interface PokemonProps {
 const Details = ({ pokemonDetails }: PokemonProps) => {
   const navigate = useNavigate();
   const pokemonEndpoint = useParams();
-
   const pokemonData = pokemonDetails.find(
     (pokemon) => pokemon.data?.name === pokemonEndpoint.pokemon
   );
+  const pokemonSpecies = useQuery({
+    queryKey: ["species", pokemonEndpoint.pokemon],
+    queryFn: () => getPokemonSpecies(pokemonEndpoint.pokemon),
+    enabled: Boolean(pokemonData?.data?.name),
+  });
 
-  console.log(pokemonData?.data);
+  console.log(pokemonSpecies.data);
 
   if (!pokemonData)
     return (
@@ -43,6 +48,11 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         </ul>
         <p>Height: {pokemonData.data.height}</p>
         <p>Weight: {pokemonData.data.weight}</p>
+        <p>Growth Rate: {pokemonSpecies.data?.growth_rate.name}</p>
+        <p>
+          Pokedex Entry:{" "}
+          {pokemonSpecies.data?.flavor_text_entries[0].flavor_text}
+        </p>
       </div>
     );
   }

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -2,6 +2,7 @@ import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { usePokemonAbility, usePokemonSpecies } from "../services/queries";
 import { getPokemonEvolutions } from "../services/api";
+import { formattedPokemonId } from "../utils/utils";
 
 interface PokemonProps {
   pokemonDetails: UseQueryResult<
@@ -46,18 +47,6 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   //     getPokemonEvolutions(pokemonSpecies?.data.evolution_chain.url),
   // });
 
-  const formatPokemonId = (pokemonId: string) => {
-    let formattedId;
-    if (pokemonId.length === 1) {
-      formattedId = `000${pokemonId}`;
-    } else if (pokemonId.length === 2) {
-      formattedId = `00${pokemonId}`;
-    } else if (pokemonId.length === 3) {
-      formattedId = `00${pokemonId}`;
-    }
-    return formattedId;
-  };
-
   if (!pokemonData)
     return (
       <p className="capitalize">Loading {pokemonEndpoint.pokemon} data...</p>
@@ -73,7 +62,7 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
           <h2 className="text-center capitalize text-2xl font-semibold ">
             {pokemonData.data.name}{" "}
             <span className=" font-light">
-              | #{formatPokemonId(String(pokemonData.data.id))}
+              | #{formattedPokemonId(String(pokemonData.data.id))}
             </span>
           </h2>
           <div className="flex border pt-4">

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,0 +1,5 @@
+const Details = () => {
+  return <span>Details Page</span>;
+};
+
+export default Details;

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,6 +1,7 @@
-import { UseQueryResult } from "@tanstack/react-query";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { usePokemonSpecies } from "../services/queries";
+import { usePokemonAbility, usePokemonSpecies } from "../services/queries";
+import { getPokemonAbility } from "../services/api";
 
 interface PokemonProps {
   pokemonDetails: UseQueryResult<
@@ -19,6 +20,10 @@ interface PokemonProps {
           url: string;
         };
       }[];
+      ability: {
+        name: string;
+        url: string;
+      };
     },
     Error
   >[];
@@ -31,8 +36,7 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
     (pokemon) => pokemon.data?.name === pokemonEndpoint.pokemon
   );
   const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
-
-  console.log(pokemonData?.data);
+  const pokemonAbility = usePokemonAbility(pokemonData?.data?.ability.url);
 
   if (!pokemonData)
     return (
@@ -59,11 +63,13 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         </p>
         <ul>
           {pokemonData.data.stats.map((stat) => (
-            <li>
+            <li key={stat.stat.url}>
               {stat.stat.name}: {stat.base_stat}
             </li>
           ))}
         </ul>
+        <p>Ability: {pokemonData.data.ability.name}</p>
+        <p>{pokemonAbility.data?.effect_entries[0].effect}</p>
       </div>
     );
   }

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,11 +1,14 @@
 import { useNavigate } from "react-router-dom";
+import { usePokemon, usePokemonDetails } from "../services/queries";
 
 const Details = () => {
   const navigate = useNavigate();
+  const pokemon = usePokemonDetails();
 
   return (
     <div>
       <button onClick={() => navigate(-1)}>Go Back</button>
+      <h2>{}</h2>
     </div>
   );
 };

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
-import { getPokemonSpecies } from "../services/api";
+import { usePokemonSpecies } from "../services/queries";
 
 interface PokemonProps {
   pokemonDetails: UseQueryResult<
@@ -11,6 +11,14 @@ interface PokemonProps {
       types: string[];
       height: number;
       weight: number;
+      stats: {
+        base_stat: number;
+        effort: number;
+        stat: {
+          name: string;
+          url: string;
+        };
+      }[];
     },
     Error
   >[];
@@ -22,13 +30,9 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   const pokemonData = pokemonDetails.find(
     (pokemon) => pokemon.data?.name === pokemonEndpoint.pokemon
   );
-  const pokemonSpecies = useQuery({
-    queryKey: ["species", pokemonEndpoint.pokemon],
-    queryFn: () => getPokemonSpecies(pokemonEndpoint.pokemon),
-    enabled: Boolean(pokemonData?.data?.name),
-  });
+  const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
 
-  console.log(pokemonSpecies.data);
+  console.log(pokemonData?.data);
 
   if (!pokemonData)
     return (
@@ -50,9 +54,16 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         <p>Weight: {pokemonData.data.weight}</p>
         <p>Growth Rate: {pokemonSpecies.data?.growth_rate.name}</p>
         <p>
-          Pokedex Entry:{" "}
+          Pokedex Entry:
           {pokemonSpecies.data?.flavor_text_entries[0].flavor_text}
         </p>
+        <ul>
+          {pokemonData.data.stats.map((stat) => (
+            <li>
+              {stat.stat.name}: {stat.base_stat}
+            </li>
+          ))}
+        </ul>
       </div>
     );
   }

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,7 +1,7 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { usePokemonAbility, usePokemonSpecies } from "../services/queries";
-import { getPokemonAbility } from "../services/api";
+import { getPokemonEvolutions } from "../services/api";
 
 interface PokemonProps {
   pokemonDetails: UseQueryResult<
@@ -38,6 +38,17 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
   const pokemonAbility = usePokemonAbility(pokemonData?.data?.ability.url);
 
+  const pokemonEvolutions = useQuery({
+    queryKey: ["evolutions"],
+    queryFn: () =>
+      getPokemonEvolutions(pokemonSpecies?.data.evolution_chain.url),
+  });
+
+  // console.log(pokemonEvolutions?.data?.chain?.evolves_to[0]);
+  console.log(
+    pokemonEvolutions?.data?.chain.evolves_to[0].evolves_to[0].species.name
+  );
+
   if (!pokemonData)
     return (
       <p className="capitalize">Loading {pokemonEndpoint.pokemon} data...</p>
@@ -70,6 +81,15 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         </ul>
         <p>Ability: {pokemonData.data.ability.name}</p>
         <p>{pokemonAbility.data?.effect_entries[0].effect}</p>
+        <h2>Evolutions</h2>
+        <p>
+          {pokemonData.data.name} ---=
+          {pokemonEvolutions?.data?.chain?.evolves_to[0].species.name} ---=
+          {
+            pokemonEvolutions?.data?.chain.evolves_to[0].evolves_to[0].species
+              .name
+          }
+        </p>
       </div>
     );
   }

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,16 +1,41 @@
-import { useNavigate } from "react-router-dom";
-import { usePokemon, usePokemonDetails } from "../services/queries";
+import { UseQueryResult } from "@tanstack/react-query";
+import { useNavigate, useParams } from "react-router-dom";
 
-const Details = () => {
+interface PokemonProps {
+  pokemonDetails: UseQueryResult<
+    {
+      name: string;
+      id: number;
+      sprites: string;
+      types: string[];
+    },
+    Error
+  >[];
+}
+
+const Details = ({ pokemonDetails }: PokemonProps) => {
   const navigate = useNavigate();
-  const pokemon = usePokemonDetails();
+  const pokemonEndpoint = useParams();
+  console.log(pokemonEndpoint.pokemon);
 
-  return (
-    <div>
-      <button onClick={() => navigate(-1)}>Go Back</button>
-      <h2>{}</h2>
-    </div>
+  const pokemonData = pokemonDetails.find(
+    (pokemon) => pokemon.data?.name === pokemonEndpoint.pokemon
   );
+
+  if (!pokemonData)
+    return (
+      <p className="capitalize">Loading {pokemonEndpoint.pokemon} data...</p>
+    );
+
+  if (pokemonData.data) {
+    return (
+      <div>
+        <button onClick={() => navigate(-1)}>Go Back</button>
+        <h2>{pokemonData.data.name}</h2>
+        <img src={pokemonData.data.sprites} alt={pokemonData.data.name} />
+      </div>
+    );
+  }
 };
 
 export default Details;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import { PokemonType } from "../types/pokemon";
 const BASE_URL = "https://pokeapi.co/api/v2";
 
 export const getPokemon = async () => {
-  const response = await fetch(`${BASE_URL}/pokemon?limit=120`);
+  const response = await fetch(`${BASE_URL}/pokemon?limit=50`);
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,8 +21,8 @@ export const getPokemonDetails = async (pokemonName: string) => {
   }
 
   const data = await response.json();
-  console.log(data);
-  const { name, id, sprites, types, weight, height, stats } = data;
+
+  const { name, id, sprites, types, weight, height, stats, abilities } = data;
 
   return {
     name,
@@ -34,6 +34,7 @@ export const getPokemonDetails = async (pokemonName: string) => {
     weight,
     height,
     stats,
+    ability: abilities[0].ability,
   };
 };
 
@@ -46,6 +47,5 @@ export const getPokemonSpecies = async (pokemonName: string) => {
 export const getPokemonAbility = async (path: string) => {
   const response = await fetch(path);
   const data = await response.json();
-  g;
   return data;
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,7 +21,7 @@ export const getPokemonDetails = async (pokemonName: string) => {
   }
 
   const data = await response.json();
-  // console.log(data);
+  console.log(data);
   const { name, id, sprites, types, weight, height } = data;
 
   return {
@@ -34,4 +34,10 @@ export const getPokemonDetails = async (pokemonName: string) => {
     weight,
     height,
   };
+};
+
+export const getPokemonSpecies = async (pokemonName: string) => {
+  const response = await fetch(`${BASE_URL}/pokemon-species/${pokemonName}`);
+  const data = await response.json();
+  return data;
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,7 +21,8 @@ export const getPokemonDetails = async (pokemonName: string) => {
   }
 
   const data = await response.json();
-  const { name, id, sprites, types } = data;
+  // console.log(data);
+  const { name, id, sprites, types, weight, height } = data;
 
   return {
     name,
@@ -30,5 +31,7 @@ export const getPokemonDetails = async (pokemonName: string) => {
     types: types.map(
       (typeInfo: { type: { name: string } }) => typeInfo.type.name
     ),
+    weight,
+    height,
   };
 };

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import { PokemonType } from "../types/pokemon";
 const BASE_URL = "https://pokeapi.co/api/v2";
 
 export const getPokemon = async () => {
-  const response = await fetch(`${BASE_URL}/pokemon?limit=151`);
+  const response = await fetch(`${BASE_URL}/pokemon?limit=100`);
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import { PokemonType } from "../types/pokemon";
 const BASE_URL = "https://pokeapi.co/api/v2";
 
 export const getPokemon = async () => {
-  const response = await fetch(`${BASE_URL}/pokemon?limit=100`);
+  const response = await fetch(`${BASE_URL}/pokemon?limit=20`);
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -42,3 +42,10 @@ export const getPokemonSpecies = async (pokemonName: string) => {
   const data = await response.json();
   return data;
 };
+
+export const getPokemonAbility = async (path: string) => {
+  const response = await fetch(path);
+  const data = await response.json();
+  g;
+  return data;
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -22,7 +22,7 @@ export const getPokemonDetails = async (pokemonName: string) => {
 
   const data = await response.json();
   console.log(data);
-  const { name, id, sprites, types, weight, height } = data;
+  const { name, id, sprites, types, weight, height, stats } = data;
 
   return {
     name,
@@ -33,6 +33,7 @@ export const getPokemonDetails = async (pokemonName: string) => {
     ),
     weight,
     height,
+    stats,
   };
 };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,13 +21,15 @@ export const getPokemonDetails = async (pokemonName: string) => {
   }
 
   const data = await response.json();
-
   const { name, id, sprites, types, weight, height, stats, abilities } = data;
 
   return {
     name,
     id,
-    sprites: sprites.front_default,
+    sprites: [
+      sprites.front_default,
+      data.sprites.other["official-artwork"].front_default,
+    ],
     types: types.map(
       (typeInfo: { type: { name: string } }) => typeInfo.type.name
     ),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -13,8 +13,8 @@ export const getPokemon = async () => {
   return data;
 };
 
-export const getPokemonDetails = async (path: string) => {
-  const response = await fetch(path);
+export const getPokemonDetails = async (pokemonName: string) => {
+  const response = await fetch(`${BASE_URL}/pokemon/${pokemonName}`);
 
   if (!response.ok) {
     throw new Error("Failed to fetch pokemon details");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import { PokemonType } from "../types/pokemon";
 const BASE_URL = "https://pokeapi.co/api/v2";
 
 export const getPokemon = async () => {
-  const response = await fetch(`${BASE_URL}/pokemon?limit=20`);
+  const response = await fetch(`${BASE_URL}/pokemon?limit=120`);
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -49,3 +49,9 @@ export const getPokemonAbility = async (path: string) => {
   const data = await response.json();
   return data;
 };
+
+export const getPokemonEvolutions = async (path: string) => {
+  const response = await fetch(path);
+  const data = await response.json();
+  return data;
+};

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -16,7 +16,7 @@ export const usePokemonDetails = (
     queries: (pokemonData.data?.results ?? []).map((pokemon) => {
       return {
         queryKey: ["pokemon", pokemon.name, "pokemonDetails"],
-        queryFn: () => getPokemonDetails(pokemon.url),
+        queryFn: () => getPokemonDetails(pokemon.name),
       };
     }),
   });

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -1,5 +1,10 @@
 import { useQueries, useQuery, UseQueryResult } from "@tanstack/react-query";
-import { getPokemon, getPokemonDetails, getPokemonSpecies } from "./api";
+import {
+  getPokemon,
+  getPokemonAbility,
+  getPokemonDetails,
+  getPokemonSpecies,
+} from "./api";
 import { PokemonType } from "../types/pokemon";
 
 export const usePokemon = () => {
@@ -27,5 +32,13 @@ export const usePokemonSpecies = (pokemonName: string) => {
     queryKey: ["species", pokemonName],
     queryFn: () => getPokemonSpecies(pokemonName),
     enabled: Boolean(pokemonName),
+  });
+};
+
+export const usePokemonAbility = (path: string) => {
+  return useQuery({
+    queryKey: ["abilities", path],
+    queryFn: () => getPokemonAbility(path),
+    enabled: Boolean(path),
   });
 };

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -21,10 +21,3 @@ export const usePokemonDetails = (
     }),
   });
 };
-
-export const usePokemonName = (name: string) => {
-  return useQuery({
-    queryKey: ["pokemonName", name],
-    queryFn: () => getPokemonDetails(name),
-  });
-};

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -21,3 +21,10 @@ export const usePokemonDetails = (
     }),
   });
 };
+
+export const usePokemonName = (name: string) => {
+  return useQuery({
+    queryKey: ["pokemonName", name],
+    queryFn: () => getPokemonDetails(name),
+  });
+};

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -1,5 +1,5 @@
 import { useQueries, useQuery, UseQueryResult } from "@tanstack/react-query";
-import { getPokemon, getPokemonDetails } from "./api";
+import { getPokemon, getPokemonDetails, getPokemonSpecies } from "./api";
 import { PokemonType } from "../types/pokemon";
 
 export const usePokemon = () => {
@@ -19,5 +19,13 @@ export const usePokemonDetails = (
         queryFn: () => getPokemonDetails(pokemon.name),
       };
     }),
+  });
+};
+
+export const usePokemonSpecies = (pokemonName: string) => {
+  return useQuery({
+    queryKey: ["species", pokemonName],
+    queryFn: () => getPokemonSpecies(pokemonName),
+    enabled: Boolean(pokemonName),
   });
 };

--- a/src/types/pokemon.ts
+++ b/src/types/pokemon.ts
@@ -7,3 +7,24 @@ export interface PokemonType {
     url: string;
   }[];
 }
+
+export interface TypeColorTypes {
+  grass: string;
+  fire: string;
+  water: string;
+  bug: string;
+  normal: string;
+  poison: string;
+  electric: string;
+  ground: string;
+  fairy: string;
+  fighting: string;
+  psychic: string;
+  rock: string;
+  ghost: string;
+  ice: string;
+  dragon: string;
+  dark: string;
+  steel: string;
+  flying: string;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,11 @@
+export const formattedPokemonId = (pokemonId: string) => {
+  let formattedId;
+  if (pokemonId.length === 1) {
+    formattedId = `000${pokemonId}`;
+  } else if (pokemonId.length === 2) {
+    formattedId = `00${pokemonId}`;
+  } else if (pokemonId.length === 3) {
+    formattedId = `00${pokemonId}`;
+  }
+  return formattedId;
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { TypeColorTypes } from "../types/pokemon";
+
 export const formattedPokemonId = (pokemonId: string) => {
   let formattedId;
   if (pokemonId.length === 1) {
@@ -8,4 +10,25 @@ export const formattedPokemonId = (pokemonId: string) => {
     formattedId = `00${pokemonId}`;
   }
   return formattedId;
+};
+
+export const typeColors: TypeColorTypes = {
+  grass: "#78C850",
+  fire: "#F08030",
+  water: "#6890F0",
+  bug: "#A8B820",
+  normal: "#A8A878",
+  poison: "#A040A0",
+  electric: "#F8D030",
+  ground: "#E0C068",
+  fairy: "#EE99AC",
+  fighting: "#C03028",
+  psychic: "#F85888",
+  rock: "#B8A038",
+  ghost: "#705898",
+  ice: "#98D8D8",
+  dragon: "#7038F8",
+  dark: "#705848",
+  steel: "#B8B8D0",
+  flying: "#A890F0",
 };


### PR DESCRIPTION
### Description
Styles both the main and detailed page. Creates multiple fetch requests such as species, and ability to display in page. Create a detailed view with navigation between the two pages. Shows more data of pokemon when clicking on a pokemon card.

### Related Issue(s)
- closes #3 

### Changes
- Add new interfaces in type files
- Create util file to store reusable functions
- Added Routes to navigate between pages
- Move usePokemon and usePokemonDetails custom hooks to App component to pass data to children components
- Add pokemon id and colored types in main page for each pokemon
- Create usePokemonAbilitites and usePokemonSpecies custom hook to get more data from pokemon
- Get the official artwork image of pokemon in usePokemon api to render it in details page
- Hover effects added to each pokemon card
- Get a limit of 50 pokemon from the getPokemon api function

### Additional Notes
- Needs to add better loading styling in main and detailed page.
- Some pokemon fetch pokemon description in a different language.
- Evolution data is received but needs to display in page
- The two new functions in api file need error handling