### PR TITLE
Feat/paginated pokemon generations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,10 @@ import { usePokemon, usePokemonDetails } from "./services/queries";
 import Favorites from "./pages/Favorites";
 
 function App() {
-  const [pokemonStartId, setPokemonStartId] = useState(0);
-  const pokemon = usePokemon(pokemonStartId);
+  const [pokemonStartId, setPokemonStartId] = useState({
+    startId: 0,
+  });
+  const pokemon = usePokemon(pokemonStartId.startId);
   const pokemonDetails = usePokemonDetails(pokemon);
   const [favorites, setFavorites] = useState([]);
 
@@ -37,10 +39,10 @@ function App() {
       <header>{<Navbar />}</header>
       <div className="flex">
         <select
-          value={pokemonStartId}
-          onChange={(e) => setPokemonStartId(e.target.value)}
+          value={pokemonStartId.startId}
+          onChange={(e) => setPokemonStartId({ startId: e.target.value })}
         >
-          <option value={0}>Generation One</option>
+          <option value={0g}>Generation One</option>
           <option value={151}>Generation two</option>
         </select>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,8 @@ import { usePokemon, usePokemonDetails } from "./services/queries";
 import Favorites from "./pages/Favorites";
 
 function App() {
-  const pokemon = usePokemon();
+  const [pokemonStartId, setPokemonStartId] = useState(0);
+  const pokemon = usePokemon(pokemonStartId);
   const pokemonDetails = usePokemonDetails(pokemon);
   const [favorites, setFavorites] = useState([]);
 
@@ -31,13 +32,19 @@ function App() {
     setFavorites(updatedFavorites);
   };
 
-  console.log(pokemon.data);
-
   return (
     <>
-      <header>
-        <Navbar />
-      </header>
+      <header>{<Navbar />}</header>
+      <div className="flex">
+        <select
+          value={pokemonStartId}
+          onChange={(e) => setPokemonStartId(e.target.value)}
+        >
+          <option value={0}>Generation One</option>
+          <option value={151}>Generation two</option>
+        </select>
+      </div>
+
       <main className="bg-slate-700 pb-10 min-h-screen">
         <Routes>
           <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,13 @@ function App() {
         >
           <option value={"0-151"}>Generation One</option>
           <option value={"151-100"}>Generation two</option>
+          <option value={"251-135"}>Generation Three</option>
+          <option value={"386-107"}>Generation Four</option>
+          <option value={"493-156"}>Generation Five</option>
+          <option value={"649-72"}>Generation Six</option>
+          <option value={"721-88"}>Generation Seven</option>
+          <option value={"809-96"}>Generation Eight</option>
+          <option value={"905-120"}>Generation Nine</option>
         </select>
       </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,9 @@ function App() {
   const [pokemonQuery, setPokemonQuery] = useState({
     startId: 0,
     limit: 151,
+    region: "Kanto",
   });
+  console.log(pokemonQuery);
   const pokemon = usePokemon(pokemonQuery.startId, pokemonQuery.limit);
   const pokemonDetails = usePokemonDetails(pokemon);
   const [favorites, setFavorites] = useState([]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,8 @@ function App() {
     setFavorites(updatedFavorites);
   };
 
+  console.log(pokemon.data);
+
   return (
     <>
       <header>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Details from "./pages/Details";
 import { useState } from "react";
 import { usePokemon, usePokemonDetails } from "./services/queries";
 import Favorites from "./pages/Favorites";
+import SelectGeneration from "./components/SelectGeneration";
 
 function App() {
   const [pokemonQuery, setPokemonQuery] = useState({
@@ -38,40 +39,22 @@ function App() {
   return (
     <>
       <header>{<Navbar />}</header>
-      <div className="flex">
-        <select
-          value={`${pokemonQuery.startId}-${pokemonQuery.limit}`}
-          onChange={(e) => {
-            const [startId, limit] = e.target.value.split("-");
-            console.log(startId, limit);
-            setPokemonQuery({
-              startId: Number(startId),
-              limit: Number(limit),
-            });
-          }}
-        >
-          <option value={"0-151"}>Generation One</option>
-          <option value={"151-100"}>Generation two</option>
-          <option value={"251-135"}>Generation Three</option>
-          <option value={"386-107"}>Generation Four</option>
-          <option value={"493-156"}>Generation Five</option>
-          <option value={"649-72"}>Generation Six</option>
-          <option value={"721-88"}>Generation Seven</option>
-          <option value={"809-96"}>Generation Eight</option>
-          <option value={"905-120"}>Generation Nine</option>
-        </select>
-      </div>
-
       <main className="bg-slate-700 pb-10 min-h-screen">
         <Routes>
           <Route
             path="/"
             element={
-              <PokemonList
-                pokemonDetails={pokemonDetails}
-                addToFavorites={addToFavorites}
-                favorites={favorites}
-              />
+              <>
+                <SelectGeneration
+                  pokemonQuery={pokemonQuery}
+                  setPokemonQuery={setPokemonQuery}
+                />
+                <PokemonList
+                  pokemonDetails={pokemonDetails}
+                  addToFavorites={addToFavorites}
+                  favorites={favorites}
+                />
+              </>
             }
           />
           <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ function App() {
     limit: 151,
     region: "Kanto",
   });
-  console.log(pokemonQuery);
   const pokemon = usePokemon(pokemonQuery.startId, pokemonQuery.limit);
   const pokemonDetails = usePokemonDetails(pokemon);
   const [favorites, setFavorites] = useState([]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,11 @@ import { usePokemon, usePokemonDetails } from "./services/queries";
 import Favorites from "./pages/Favorites";
 
 function App() {
-  const [pokemonStartId, setPokemonStartId] = useState({
+  const [pokemonQuery, setPokemonQuery] = useState({
     startId: 0,
+    limit: 151,
   });
-  const pokemon = usePokemon(pokemonStartId.startId);
+  const pokemon = usePokemon(pokemonQuery.startId, pokemonQuery.limit);
   const pokemonDetails = usePokemonDetails(pokemon);
   const [favorites, setFavorites] = useState([]);
 
@@ -39,11 +40,18 @@ function App() {
       <header>{<Navbar />}</header>
       <div className="flex">
         <select
-          value={pokemonStartId.startId}
-          onChange={(e) => setPokemonStartId({ startId: e.target.value })}
+          value={`${pokemonQuery.startId}-${pokemonQuery.limit}`}
+          onChange={(e) => {
+            const [startId, limit] = e.target.value.split("-");
+            console.log(startId, limit);
+            setPokemonQuery({
+              startId: Number(startId),
+              limit: Number(limit),
+            });
+          }}
         >
-          <option value={0g}>Generation One</option>
-          <option value={151}>Generation two</option>
+          <option value={"0-151"}>Generation One</option>
+          <option value={"151-100"}>Generation two</option>
         </select>
       </div>
 

--- a/src/components/PokemonList.tsx
+++ b/src/components/PokemonList.tsx
@@ -48,7 +48,10 @@ const PokemonList = ({
     (query) => query.status === "error"
   );
 
-  if (areAnyPending) return <span>Loading data...</span>;
+  if (areAnyPending)
+    return (
+      <p className="text-white text-center text-lg pt-10">Loading data...</p>
+    );
   if (areAnyFailing) return <span>Can't load pokemon data</span>;
 
   const pokemonElements = pokemonDetails.map(

--- a/src/components/SelectGeneration.tsx
+++ b/src/components/SelectGeneration.tsx
@@ -1,27 +1,30 @@
 const SelectGeneration = ({ pokemonQuery, setPokemonQuery }) => {
   return (
-    <div className="flex justify-end border border-red-300 max-w-[1200px] mx-auto pt-10">
+    <div className="flex justify-between items-center max-w-[1200px] mx-auto pt-10">
+      <h2 className="text-white text-5xl font-semibold ">
+        {pokemonQuery.region} Region
+      </h2>
       <select
         className="w-[200px] p-1 rounded-sm"
-        value={`${pokemonQuery.startId}-${pokemonQuery.limit}`}
+        value={`${pokemonQuery.startId}-${pokemonQuery.limit}-${pokemonQuery.region}`}
         onChange={(e) => {
-          const [startId, limit] = e.target.value.split("-");
-          console.log(startId, limit);
+          const [startId, limit, region] = e.target.value.split("-");
           setPokemonQuery({
             startId: Number(startId),
             limit: Number(limit),
+            region,
           });
         }}
       >
-        <option value={"0-151"}>Generation One</option>
-        <option value={"151-100"}>Generation two</option>
-        <option value={"251-135"}>Generation Three</option>
-        <option value={"386-107"}>Generation Four</option>
-        <option value={"493-156"}>Generation Five</option>
-        <option value={"649-72"}>Generation Six</option>
-        <option value={"721-88"}>Generation Seven</option>
-        <option value={"809-96"}>Generation Eight</option>
-        <option value={"905-120"}>Generation Nine</option>
+        <option value={"0-151-Kanto"}>Generation One</option>
+        <option value={"151-100-Johto"}>Generation Two</option>
+        <option value={"251-135-Hoenn"}>Generation Three</option>
+        <option value={"386-107-Sinnoh"}>Generation Four</option>
+        <option value={"493-156-Unova"}>Generation Five</option>
+        <option value={"649-72-Kalos"}>Generation Six</option>
+        <option value={"721-88-Alola"}>Generation Seven</option>
+        <option value={"809-96-Galar"}>Generation Eight</option>
+        <option value={"905-120-Paldea"}>Generation Nine</option>
       </select>
     </div>
   );

--- a/src/components/SelectGeneration.tsx
+++ b/src/components/SelectGeneration.tsx
@@ -1,0 +1,30 @@
+const SelectGeneration = ({ pokemonQuery, setPokemonQuery }) => {
+  return (
+    <div className="flex justify-end border border-red-300 max-w-[1200px] mx-auto pt-10">
+      <select
+        className="w-[200px] p-1 rounded-sm"
+        value={`${pokemonQuery.startId}-${pokemonQuery.limit}`}
+        onChange={(e) => {
+          const [startId, limit] = e.target.value.split("-");
+          console.log(startId, limit);
+          setPokemonQuery({
+            startId: Number(startId),
+            limit: Number(limit),
+          });
+        }}
+      >
+        <option value={"0-151"}>Generation One</option>
+        <option value={"151-100"}>Generation two</option>
+        <option value={"251-135"}>Generation Three</option>
+        <option value={"386-107"}>Generation Four</option>
+        <option value={"493-156"}>Generation Five</option>
+        <option value={"649-72"}>Generation Six</option>
+        <option value={"721-88"}>Generation Seven</option>
+        <option value={"809-96"}>Generation Eight</option>
+        <option value={"905-120"}>Generation Nine</option>
+      </select>
+    </div>
+  );
+};
+
+export default SelectGeneration;

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -41,7 +41,9 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
 
   if (!pokemonData)
     return (
-      <p className="capitalize">Loading {pokemonEndpoint.pokemon} data...</p>
+      <p className="text-white text-center pt-10 capitalize">
+        Loading {pokemonEndpoint.pokemon} data...
+      </p>
     );
 
   if (pokemonData.data) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,9 +1,23 @@
 import { PokemonType } from "../types/pokemon";
 
+// GEN 1 - 151
+// GEN 2 - 100
+// GEN 3 - 135
+// GEN 4 - 107
+// GEN 5 - 156
+// GEN 6 - 72
+// GEN 7 - 88
+// GEN 8 - 96
+// GEN 9 - 120
+
+// Need a limit for each generation and the offset of which is next. The last number of prev generation
+
 const BASE_URL = "https://pokeapi.co/api/v2";
 
-export const getPokemon = async () => {
-  const response = await fetch(`${BASE_URL}/pokemon?limit=151`);
+export const getPokemon = async (offset = 0, limit = 151) => {
+  const response = await fetch(
+    `${BASE_URL}/pokemon?offset=${offset}&limit=${limit}`
+  );
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,10 +14,8 @@ import { PokemonType } from "../types/pokemon";
 
 const BASE_URL = "https://pokeapi.co/api/v2";
 
-export const getPokemon = async (offset = 0, limit = 151) => {
-  const response = await fetch(
-    `${BASE_URL}/pokemon?offset=${offset}&limit=${limit}`
-  );
+export const getPokemon = async (startId: number) => {
+  const response = await fetch(`${BASE_URL}/pokemon?offset=${startId}&limit=3`);
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,17 +1,5 @@
 import { PokemonType } from "../types/pokemon";
 
-// GEN 1 - 151
-// GEN 2 - 100
-// GEN 3 - 135
-// GEN 4 - 107
-// GEN 5 - 156
-// GEN 6 - 72
-// GEN 7 - 88
-// GEN 8 - 96
-// GEN 9 - 120
-
-// Need a limit for each generation and the offset of which is next. The last number of prev generation
-
 const BASE_URL = "https://pokeapi.co/api/v2";
 
 export const getPokemon = async (startId: number, limit: number) => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,8 +14,10 @@ import { PokemonType } from "../types/pokemon";
 
 const BASE_URL = "https://pokeapi.co/api/v2";
 
-export const getPokemon = async (startId: number) => {
-  const response = await fetch(`${BASE_URL}/pokemon?offset=${startId}&limit=3`);
+export const getPokemon = async (startId: number, limit: number) => {
+  const response = await fetch(
+    `${BASE_URL}/pokemon?offset=${startId}&limit=${limit}`
+  );
 
   if (!response.ok) {
     throw new Error("Fetch status is not successful");

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -7,10 +7,10 @@ import {
 } from "./api";
 import { PokemonType } from "../types/pokemon";
 
-export const usePokemon = () => {
+export const usePokemon = (startId: number) => {
   return useQuery({
-    queryKey: ["pokemon"],
-    queryFn: getPokemon,
+    queryKey: ["pokemon", startId],
+    queryFn: () => getPokemon(startId),
   });
 };
 

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -7,10 +7,10 @@ import {
 } from "./api";
 import { PokemonType } from "../types/pokemon";
 
-export const usePokemon = (startId: number) => {
+export const usePokemon = (startId: number, limit: number) => {
   return useQuery({
-    queryKey: ["pokemon", startId],
-    queryFn: () => getPokemon(startId),
+    queryKey: ["pokemon", { startId, limit }],
+    queryFn: () => getPokemon(startId, limit),
   });
 };
 

--- a/src/ui/Navbar.tsx
+++ b/src/ui/Navbar.tsx
@@ -2,11 +2,13 @@ import { NavLink } from "react-router-dom";
 
 const Navbar = () => {
   return (
-    <nav className="bg-red-500 text-white px-10 py-4 flex items-end justify-between">
-      <h2 className="text-2xl">Trainers Pokedex</h2>
-      <NavLink to="pokedex/favorites" className="text-xl">
-        Favorites
-      </NavLink>
+    <nav className="bg-red-500 text-white px-10 py-2">
+      <div className="max-w-[1200px] flex items-end justify-between mx-auto">
+        <h2 className="text-xl">Trainers Pokedex</h2>
+        <NavLink to="pokedex/favorites" className="text-xl">
+          Favorites
+        </NavLink>
+      </div>
     </nav>
   );
 };


### PR DESCRIPTION
### Description
Add select input that generates different pokemon to the page depending in which region it's from. Displays a sub heading for the region name and adjusts styling for input and navbar.

### Related Issue(s)
- closes #7 

### Changes
- Adds two new parameters for getPokemon async function (The startId and limit of pokemon)
- Custom hook takes in the two arguments 
- QueryKey uses the two arguments to invalidate the cache
- App component has new state to keep track of the arguments
- Creates new SelectGeneration component to render and have dynamic select functionality by using the state passed from App component
- Styling has been updated

### Additional Notes
Found a bug were when the user refreshes the page in details for a pokemon that's not part of generation one, the page can't get the details data for that pokemon.

### Dependencies
None