### PR TITLE
Fix/different languages displayed

### DIFF
--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -98,7 +98,12 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
               </ul>
               <p>Height: {pokemonData.data.height}</p>
               <p>Weight: {pokemonData.data.weight}</p>
-              <p>Growth Rate: {pokemonSpecies.data?.growth_rate.name}</p>
+              <p>
+                Growth Rate:{" "}
+                <span className="capitalize">
+                  {pokemonSpecies.data?.growth_rate}
+                </span>
+              </p>
               <p className="capitalize">
                 Ability: {pokemonData.data.ability.name}
               </p>

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -40,8 +40,6 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
   const pokemonAbility = usePokemonAbility(pokemonData?.data?.ability.url);
 
-  console.log(pokemonSpecies?.data);
-
   const pokemonStats = pokemonData?.data?.stats;
 
   const formattedStats = pokemonStats?.map((stat) => {
@@ -57,8 +55,6 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         Loading {pokemonEndpoint.pokemon} data...
       </p>
     );
-
-  // I need the growth rate and .flavor_text_entries[0].flavor_text in english
 
   if (pokemonData.data) {
     return (
@@ -106,7 +102,7 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
               <p className="capitalize">
                 Ability: {pokemonData.data.ability.name}
               </p>
-              <p>{pokemonAbility.data?.effect_entries[0].effect}</p>
+              <p>{pokemonAbility.data?.abilityEffect}</p>
             </div>
           </div>
           <div className="h-[500px] mt-20 ">

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -40,6 +40,8 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
   const pokemonSpecies = usePokemonSpecies(pokemonData?.data.name);
   const pokemonAbility = usePokemonAbility(pokemonData?.data?.ability.url);
 
+  console.log(pokemonSpecies?.data);
+
   const pokemonStats = pokemonData?.data?.stats;
 
   const formattedStats = pokemonStats?.map((stat) => {
@@ -55,6 +57,8 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
         Loading {pokemonEndpoint.pokemon} data...
       </p>
     );
+
+  // I need the growth rate and .flavor_text_entries[0].flavor_text in english
 
   if (pokemonData.data) {
     return (
@@ -78,7 +82,7 @@ const Details = ({ pokemonDetails }: PokemonProps) => {
               />
             </div>
             <div className="w-[55%] space-y-2">
-              <p>{pokemonSpecies.data?.flavor_text_entries[0].flavor_text}</p>
+              <p>{pokemonSpecies.data?.description}</p>
               <h3 className="text-xl font-medium">Type</h3>
               <ul className="flex gap-x-2 capitalize text-center text-white">
                 {pokemonData.data.types.map((type) => (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -44,8 +44,20 @@ export const getPokemonDetails = async (pokemonName: string) => {
 
 export const getPokemonSpecies = async (pokemonName: string) => {
   const response = await fetch(`${BASE_URL}/pokemon-species/${pokemonName}`);
+
+  if (!response.ok) {
+    throw new Error("Can't get species");
+  }
+
   const data = await response.json();
-  return data;
+  const { flavor_text_entries, growth_rate } = data;
+  return {
+    description: flavor_text_entries.find(
+      (description: { language: { name: string } }) =>
+        description.language.name === "en"
+    ).flavor_text,
+    growth_rate: growth_rate.name,
+  };
 };
 
 export const getPokemonAbility = async (path: string) => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -62,8 +62,19 @@ export const getPokemonSpecies = async (pokemonName: string) => {
 
 export const getPokemonAbility = async (path: string) => {
   const response = await fetch(path);
+
+  if (!response.ok) {
+    throw new Error("Can't get ability from Pokemon");
+  }
   const data = await response.json();
-  return data;
+  const { effect_entries } = data;
+  return {
+    abilityEffect: effect_entries.find(
+      (effect: { language: { name: string } }) => {
+        return effect.language.name === "en";
+      }
+    ).effect,
+  };
 };
 
 export const getPokemonEvolutions = async (path: string) => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,9 @@ export const formattedPokemonId = (pokemonId: string) => {
   } else if (pokemonId.length === 2) {
     formattedId = `00${pokemonId}`;
   } else if (pokemonId.length === 3) {
-    formattedId = `00${pokemonId}`;
+    formattedId = `0${pokemonId}`;
+  } else {
+    formattedId = pokemonId;
   }
   return formattedId;
 };


### PR DESCRIPTION
### Description
Different languages were appearing in details page for different Pokemon. This has been fixed by only displaying the text in english.

### Related Issue(s)

### Changes
- Added error handling inside api file for getPokemonSpecies and getPokemonAbitlity.
- Abstracted the data received from the api to only get necessary data needed to display in details page.
- Fix function that formats Pokemon's id to not render an extra 0 in when the id hits 4 digits.

### Additional Notes

### Dependencies
