### PR TITLE
Feat/details error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Favorites from "./pages/Favorites";
 import SelectGeneration from "./components/SelectGeneration";
 import SearchBar from "./components/SearchBar";
 import PokemonStatsComparison from "./pages/PokemonStatsComparison";
+import ScrollToTop from "./components/ScrollToTop";
 
 function App() {
   const [pokemonQuery, setPokemonQuery] = useState({
@@ -45,6 +46,7 @@ function App() {
       <header>{<Navbar />}</header>
 
       <main className="bg-slate-700 pb-10 min-h-screen">
+        <ScrollToTop />
         <Routes>
           <Route
             path="/"

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { usePokemonAbility, usePokemonSpecies } from "../services/queries";
 import { formattedPokemonId, typeColors } from "../utils/utils";
 import { TypeColorTypes } from "../types/pokemon";
@@ -37,7 +37,19 @@ const Details = () => {
       </p>
     );
   } else if (isError) {
-    detailsContent = <span>Error loading pokemon</span>;
+    detailsContent = (
+      <div className="text-center text-white mt-10">
+        <p className="text-xl">
+          There's been an error fetching data for {pokemonEndpoint.pokemon}.
+        </p>
+        <button
+          className="bg-white text-black rounded-md px-3 py-1 mt-4 font-medium hover:bg-red-700 hover:text-white"
+          onClick={() => navigate(-1)}
+        >
+          Go Back
+        </button>
+      </div>
+    );
   } else {
     detailsContent = (
       <div className="bg-slate-100 py-8 rounded-xl">

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -9,14 +9,18 @@ import { getPokemonInfo } from "../services/api";
 const Details = () => {
   const navigate = useNavigate();
   const pokemonEndpoint = useParams();
-  const pokemonInfo = useQuery({
+  const {
+    data: pokemonInfo,
+    isPending,
+    isError,
+  } = useQuery({
     queryKey: ["pokemonDetails", pokemonEndpoint.pokemon],
     queryFn: () => getPokemonInfo(pokemonEndpoint.pokemon),
   });
   const pokemonSpecies = usePokemonSpecies(pokemonEndpoint.pokemon);
-  const pokemonAbility = usePokemonAbility(pokemonInfo?.data?.ability.url);
+  const pokemonAbility = usePokemonAbility(pokemonInfo?.ability.url);
 
-  const pokemonStats = pokemonInfo?.data?.stats;
+  const pokemonStats = pokemonInfo?.stats;
 
   const formattedStats = pokemonStats?.map((stat) => {
     return {
@@ -25,42 +29,37 @@ const Details = () => {
     };
   });
 
-  if (pokemonInfo.status === "pending")
-    return (
+  let detailsContent;
+  if (isPending) {
+    detailsContent = (
       <p className="text-white text-center pt-10 capitalize">
         Loading {pokemonEndpoint.pokemon} data...
       </p>
     );
-
-  if (pokemonInfo.status === "error") return <span>Error loading pokemon</span>;
-
-  console.log(pokemonInfo.status);
-
-  return (
-    <section className="max-w-[1200px] mx-auto">
-      <button className="my-6 text-white" onClick={() => navigate(-1)}>
-        &larr; Go Back
-      </button>
+  } else if (isError) {
+    detailsContent = <span>Error loading pokemon</span>;
+  } else {
+    detailsContent = (
       <div className="bg-slate-100 py-8 rounded-xl">
         <h2 className="text-center capitalize text-2xl font-semibold pb-4">
-          {pokemonInfo.data.name}{" "}
+          {pokemonInfo.name}{" "}
           <span className=" font-light">
-            | #{formattedPokemonId(String(pokemonInfo.data.id))}
+            | #{formattedPokemonId(String(pokemonInfo.id))}
           </span>
         </h2>
         <div className="flex w-[90%] justify-center gap-x-6 mx-auto py-4">
           <div className="w-[35%]">
             <img
               className="object-cover bg-gray-300 rounded-lg"
-              src={pokemonInfo.data.sprites[1]}
-              alt={pokemonInfo.data.name}
+              src={pokemonInfo.sprites[1]}
+              alt={pokemonInfo.name}
             />
           </div>
           <div className="w-[55%] space-y-2">
             <p>{pokemonSpecies.data?.description}</p>
             <h3 className="text-xl font-medium">Type</h3>
             <ul className="flex gap-x-2 capitalize text-center text-white">
-              {pokemonInfo.data.types.map((type) => (
+              {pokemonInfo.types.map((type) => (
                 <li
                   style={{
                     backgroundColor: typeColors[type as keyof TypeColorTypes],
@@ -75,17 +74,15 @@ const Details = () => {
                 </li>
               ))}
             </ul>
-            <p>Height: {pokemonInfo.data.height}</p>
-            <p>Weight: {pokemonInfo.data.weight}</p>
+            <p>Height: {pokemonInfo.height}</p>
+            <p>Weight: {pokemonInfo.weight}</p>
             <p>
               Growth Rate:{" "}
               <span className="capitalize">
                 {pokemonSpecies.data?.growth_rate}
               </span>
             </p>
-            <p className="capitalize">
-              Ability: {pokemonInfo.data.ability.name}
-            </p>
+            <p className="capitalize">Ability: {pokemonInfo.ability.name}</p>
             <p>{pokemonAbility.data?.abilityEffect}</p>
           </div>
         </div>
@@ -96,6 +93,15 @@ const Details = () => {
           <StatsBar formattedStats={formattedStats} />
         </div>
       </div>
+    );
+  }
+
+  return (
+    <section className="max-w-[1200px] mx-auto">
+      <button className="my-6 text-white" onClick={() => navigate(-1)}>
+        &larr; Go Back
+      </button>
+      {detailsContent}
     </section>
   );
 };

--- a/src/pages/Details.tsx
+++ b/src/pages/Details.tsx
@@ -13,7 +13,7 @@ const Details = () => {
     queryKey: ["pokemonDetails", pokemonEndpoint.pokemon],
     queryFn: () => getPokemonInfo(pokemonEndpoint.pokemon),
   });
-  const pokemonSpecies = usePokemonSpecies(pokemonInfo.data?.name);
+  const pokemonSpecies = usePokemonSpecies(pokemonEndpoint.pokemon);
   const pokemonAbility = usePokemonAbility(pokemonInfo?.data?.ability.url);
 
   const pokemonStats = pokemonInfo?.data?.stats;
@@ -25,11 +25,7 @@ const Details = () => {
     };
   });
 
-  if (
-    pokemonInfo.status === "pending" ||
-    pokemonSpecies.status === "pending" ||
-    pokemonAbility.status === "pending"
-  )
+  if (pokemonInfo.status === "pending")
     return (
       <p className="text-white text-center pt-10 capitalize">
         Loading {pokemonEndpoint.pokemon} data...
@@ -37,6 +33,8 @@ const Details = () => {
     );
 
   if (pokemonInfo.status === "error") return <span>Error loading pokemon</span>;
+
+  console.log(pokemonInfo.status);
 
   return (
     <section className="max-w-[1200px] mx-auto">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -77,8 +77,28 @@ export const getPokemonAbility = async (path: string) => {
   };
 };
 
-export const getPokemonEvolutions = async (path: string) => {
-  const response = await fetch(path);
+export const getPokemonInfo = async (pokemonName: string) => {
+  const response = await fetch(`${BASE_URL}/pokemon/${pokemonName}`);
+
+  if (!response.ok) {
+    throw new Error("Can't get Pokemon Info");
+  }
+
   const data = await response.json();
-  return data;
+  const { name, id, sprites, types, weight, height, stats, abilities } = data;
+  return {
+    name,
+    id,
+    sprites: [
+      sprites.front_default,
+      data.sprites.other["official-artwork"].front_default,
+    ],
+    types: types.map(
+      (typeInfo: { type: { name: string } }) => typeInfo.type.name
+    ),
+    weight,
+    height,
+    stats,
+    ability: abilities[0].ability,
+  };
 };

--- a/src/services/queries.ts
+++ b/src/services/queries.ts
@@ -31,7 +31,6 @@ export const usePokemonSpecies = (pokemonName: string) => {
   return useQuery({
     queryKey: ["species", pokemonName],
     queryFn: () => getPokemonSpecies(pokemonName),
-    enabled: Boolean(pokemonName),
   });
 };
 


### PR DESCRIPTION
### Description
Updates the way that the details page content loads and handles an error when unknown Pokemon was fetched. Makes sure to navigate to the top of the page when switching between the pages.

### Related Issue(s)
None 

### Changes
- Create new ScrollToTop component that contains logic to navigate to the top of the page when navigating different pages.
- Details component no longer takes prop to get name from app component 
- Details uses React Query to handle deduplication using it's build in observers to keep track of the queryKey
- Handle content by the status of react query.
- Add new error message when failed to get data and include new back button

### Additional Notes


### Dependencies
None